### PR TITLE
Update to Android Studio Dolphin

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@
   |環境／FW                                                                                           |端末       |日付
   |---------------------------------------------------------------------------------------------------|-----------|----------
   |Visual Studio Community 2022 17.4.0 Preview 2.0 + .NET 6.0.400 Preview/.NET 7.0.0-preview.7.22375.6|IdeaPad    |2022/09/16
-  |Visual Studio Community 2022 17.4.0 Preview 2.0 + .NET 6.0.400 Preview + .NET MAUI                 |ExpertBook |2022/09/16
+  |Visual Studio Community 2022 17.4.0 Preview 2.1 + .NET 6.0.400 Preview + .NET MAUI                 |ExpertBook |2022/09/23
   |Android SDK Platform 33 / Platform-Tools 33.0.2 / Android Emulator 31.2.10                         |           |2022/07/09
 
   - C#
@@ -258,16 +258,21 @@
 
   |環境／FW                                                     |端末       |日付
   |-------------------------------------------------------------|-----------|----------
-  |[Flutter 3.3.1](https://docs.flutter.dev/get-started/install)|ExpertBook |2022/09/09
+  |[Flutter 3.3.2](https://docs.flutter.dev/get-started/install)|ExpertBook |2022/09/23
 
-  - flutter doctorの出力
+  - flutterの更新
     ```
-    [√] Flutter (Channel stable, 3.3.1, on Microsoft Windows [Version 10.0.22000.856], locale ja-JP)
-        • Flutter version 3.3.1 on channel stable at D:\flutter
+    flutter upgrade
+    ```
+
+  - flutter doctor -vの出力
+    ```
+    [√] Flutter (Channel stable, 3.3.2, on Microsoft Windows [Version 10.0.22000.856], locale ja-JP)
+        • Flutter version 3.3.2 on channel stable at D:\flutter
         • Upstream repository https://github.com/flutter/flutter.git
-        • Framework revision 4f9d92fbbd (3 days ago), 2022-09-06 17:54:53 -0700
-        • Engine revision 3efdf03e73
-        • Dart version 2.18.0
+        • Framework revision e3c29ec00c (9 days ago), 2022-09-14 08:46:55 -0500
+        • Engine revision a4ff2c53d8
+        • Dart version 2.18.1
         • DevTools version 2.15.0
 
     [√] Android toolchain - develop for Android devices (Android SDK version 33.0.0)
@@ -280,9 +285,9 @@
     [√] Chrome - develop for the web
         • Chrome at C:\Program Files\Google\Chrome\Application\chrome.exe
 
-    [√] Visual Studio - develop for Windows (Visual Studio Community 2022 17.4.0 Preview 1.0)
+    [√] Visual Studio - develop for Windows (Visual Studio Community 2022 17.4.0 Preview 2.1)
         • Visual Studio at D:\Program Files\Microsoft Visual Studio\2022\Preview
-        • Visual Studio Community 2022 version 17.4.32804.182
+        • Visual Studio Community 2022 version 17.4.32916.344
         • The current Visual Studio installation is a pre-release version. It may not be supported by Flutter yet.
         • Windows 10 SDK version 10.0.22000.0
 
@@ -294,16 +299,15 @@
           https://plugins.jetbrains.com/plugin/6351-dart
         • Java version OpenJDK Runtime Environment (build 11.0.12+7-b1504.28-7817840)
 
-    [√] VS Code (version 1.71.0)
+    [√] VS Code (version 1.71.2)
         • VS Code at C:\Users\taish\AppData\Local\Programs\Microsoft VS Code
         • Flutter extension can be installed from:
           https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
 
-    [√] Connected device (4 available)
-        • Android SDK built for x86 (mobile) • emulator-5554 • android-x86    • Android 11 (API 30) (emulator)
-        • Windows (desktop)                  • windows       • windows-x64    • Microsoft Windows [Version 10.0.22000.856]    
-        • Chrome (web)                       • chrome        • web-javascript • Google Chrome 105.0.5195.102
-        • Edge (web)                         • edge          • web-javascript • Microsoft Edge 105.0.1343.27
+    [√] Connected device (3 available)
+        • Windows (desktop) • windows • windows-x64    • Microsoft Windows [Version 10.0.22000.856]
+        • Chrome (web)      • chrome  • web-javascript • Google Chrome 105.0.5195.102
+        • Edge (web)        • edge    • web-javascript • Microsoft Edge 105.0.1343.42
 
     [√] HTTP Host Availability
         • All required HTTP hosts are available

--- a/README.md
+++ b/README.md
@@ -117,8 +117,10 @@
     Memory: 1280M
     Cores: 4
     Registry: external.system.auto.import.disabled=true
-    Non-Bundled Plugins: Dart (212.5744), org.jetbrains.kotlin (212-1.7.10-release-333-AS5457.46), io.flutter (70.0.2)
+    Non-Bundled Plugins: org.jetbrains.kotlin (212-1.7.10-release-333-AS5457.46), Dart (212.5744), io.flutter (70.0.2)
     ```
+    - Dolphin 対応
+      [アップデート後起動時例外発生](kotlin/Android/Update_to_Dolphin.md) **@2022/09/24**
     - Chipmunk 対応
       - Gradle 7.3.3 and Android Gradle Plugin 7.2.0
     - Arctic Fox 対応として吸収すべき課題

--- a/README.md
+++ b/README.md
@@ -234,6 +234,36 @@
   |Visual Studio Community 2022 17.4.0 Preview 2.1 + .NET 6.0.400 Preview + .NET MAUI                 |ExpertBook |2022/09/23
   |Android SDK Platform 33 / Platform-Tools 33.0.2 / Android Emulator 31.2.10                         |           |2022/07/09
 
+  - .NET 環境情報
+    ```
+    dotnet --info
+    ```
+    ```
+    .NET SDK:
+    Version:   7.0.100-rc.1.22431.12
+    Commit:    f1cf61e1c0
+
+    ランタイム環境:
+    OS Name:     Windows
+    OS Version:  10.0.22000
+    OS Platform: Windows
+    RID:         win10-x64
+    Base Path:   C:\Program Files\dotnet\sdk\7.0.100-rc.1.22431.12\
+    Other architectures found:
+      x86   [C:\Program Files (x86)\dotnet]
+
+    Environment variables:
+      Not set
+
+    global.json file:
+      Not found
+
+    Learn more:
+      https://aka.ms/dotnet/info
+
+    Download .NET:
+      https://aka.ms/dotnet/download
+    ```
   - C#
     - [やさしいＣ＃第３版](https://isbn2.sbcr.jp/03922/)
       - [サポートページ](http://mana.on.coocan.jp/yasacs.html)

--- a/kotlin/Android/Update_to_Dolphin.md
+++ b/kotlin/Android/Update_to_Dolphin.md
@@ -1,0 +1,84 @@
+*   起動時例外発生
+    ```
+        内部エラーが発生しました。Please refer to https://code.google.com/p/android/issues
+
+    com.intellij.ide.plugins.StartupAbortedException: UI initialization failed
+        at com.intellij.idea.StartupUtil.lambda$start$15(StartupUtil.java:268)
+        at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:986)
+        at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:970)
+        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
+        at java.base/java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:610)
+        at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:791)
+        at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:478)
+        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
+        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:776)
+        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
+        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
+        at java.base/java.security.AccessController.doPrivileged(Native Method)
+        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
+        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:746)
+        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
+        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
+        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
+        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
+        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
+        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
+    Caused by: java.util.concurrent.CompletionException: java.lang.VerifyError: Expecting a stack map frame
+    Exception Details:
+    Location:
+        com/intellij/openapi/util/text/StringUtil.pluralize(Ljava/lang/String;I)Ljava/lang/String; @7: nop
+    Reason:
+        Expected stackmap frame at this location.
+    Bytecode:
+        0000000: 2ab0 0000 a7ff fe00 bf00 00a7 fffe     
+    Stackmap Table:
+        same_frame(@2)
+        same_frame(@9)
+
+        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314)
+        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319)
+        at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:787)
+        ... 14 more
+    Caused by: java.lang.VerifyError: Expecting a stack map frame
+    Exception Details:
+    Location:
+        com/intellij/openapi/util/text/StringUtil.pluralize(Ljava/lang/String;I)Ljava/lang/String; @7: nop
+    Reason:
+        Expected stackmap frame at this location.
+    Bytecode:
+        0000000: 2ab0 0000 a7ff fe00 bf00 00a7 fffe     
+    Stackmap Table:
+        same_frame(@2)
+        same_frame(@9)
+
+        at com.intellij.openapi.util.SystemInfo.isOsVersionAtLeast(SystemInfo.java:51)
+        at com.intellij.openapi.util.SystemInfo.<clinit>(SystemInfo.java:54)
+        at com.intellij.ui.JreHiDpiUtil.isJreHiDPIEnabled(JreHiDpiUtil.java:58)
+        at com.intellij.ui.scale.JBUIScale.getOrComputeUserScaleFactor(JBUIScale.java:190)
+        at com.intellij.ui.scale.JBUIScale.scale(JBUIScale.java:314)
+        at com.intellij.ui.scale.UserScaleContext.<init>(UserScaleContext.java:26)
+        at com.intellij.util.ui.JBUI$BaseScaleContext.<init>(JBUI.java:1408)
+        at com.intellij.ui.scale.ScaleContext.<init>(ScaleContext.java:32)
+        at com.intellij.ui.scale.ScaleContext.create(ScaleContext.java:108)
+        at com.intellij.ui.scale.ScaleContextSupport.<init>(ScaleContextSupport.java:11)
+        at com.intellij.openapi.util.IconLoader$CachedImageIcon.<init>(IconLoader.java:702)
+        at com.intellij.ui.CoreIconManager$IconWithToolTipImpl.<init>(CoreIconManager.java:91)
+        at com.intellij.ui.CoreIconManager.loadRasterizedIcon(CoreIconManager.java:61)
+        at com.intellij.icons.AllIcons.load(AllIcons.java:17)
+        at com.intellij.icons.AllIcons.<clinit>(AllIcons.java:670)
+        at com.intellij.icons.AllIcons$Nodes.<clinit>(AllIcons.java:719)
+        at com.intellij.ide.ui.laf.IdeaLaf.initIdeaDefaults(IdeaLaf.java:74)
+        at com.intellij.ide.ui.laf.IdeaLaf.initComponentDefaults(IdeaLaf.java:35)
+        at java.desktop/javax.swing.plaf.basic.BasicLookAndFeel.getDefaults(BasicLookAndFeel.java:150)
+        at java.desktop/javax.swing.plaf.metal.MetalLookAndFeel.getDefaults(MetalLookAndFeel.java:1560)
+        at com.intellij.idea.StartupUtil.lambda$scheduleInitUi$21(StartupUtil.java:476)
+        at com.intellij.ui.scale.JBUIScale.computeSystemFontData(JBUIScale.java:69)
+        at com.intellij.ui.scale.JBUIScale.getSystemFontData(JBUIScale.java:360)
+        at com.intellij.idea.StartupUtil.lambda$scheduleInitUi$22(StartupUtil.java:474)
+        at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:783)
+        ... 14 more
+
+    -----
+    Your JRE: 11.0.13+0-b1751.21-8125866 amd64 (JetBrains s.r.o.)
+    D:\Program Files\Android\Android Studio\jre
+    ```


### PR DESCRIPTION
Android Studio Dolphinへアップデートしたものの、起動時に例外が発生してしまうため、見送り。
同時に更新を行ったFlutterおよびVisual Studio 2022のみ有効として、Readmeの更新を反映する