### PR TITLE
Add: Implementation to set main window visible

### DIFF
--- a/rust/tauri-app-win/tauri-app/src-tauri/src/lib.rs
+++ b/rust/tauri-app-win/tauri-app/src-tauri/src/lib.rs
@@ -56,14 +56,18 @@ pub fn run() {
         .on_tray_icon_event(|tray, event| {
             // System tray event handling (left-click, right-click, double-click)
             if event.click_type == ClickType::Left {
-              println!("system tray received a left click");
+              let app = tray.app_handle();
+              if let Some(webview_window) = app.get_webview_window("main") {
+                let _ = webview_window.show();
+                let _ = webview_window.set_focus();
+              }
             }
-            if event.click_type == ClickType::Right {
-              println!("system tray received a right click");
-            }
-            if event.click_type == ClickType::Double {
-              println!("system tray received a double click");
-            }
+            //if event.click_type == ClickType::Right {
+            //  println!("system tray received a right click");
+            //}
+            //if event.click_type == ClickType::Double {
+            //  println!("system tray received a double click");
+            //}
         })
         .build(app)?;
       let splashscreen_window = app.get_webview_window("splashscreen").unwrap();


### PR DESCRIPTION
#1149 残課題の一部として、システムトレイのアイコンを左クリックした場合に
メインウィンドウを表示する処理を追加
（移行ガイドのサンプルコードを参照）