### PR TITLE
Fix: WebApp @IT Vol.5

### DIFF
--- a/rust/ITWebApp/actix-sample/src/handler.rs
+++ b/rust/ITWebApp/actix-sample/src/handler.rs
@@ -37,11 +37,19 @@ pub async fn index(tmpl: web::Data<tera::Tera>, messages: IncomingFlashMessages)
 
 /// ##  投稿表示
 #[get("/posts/{id}")]
-pub async fn show(tmpl: web::Data<tera::Tera>, info: web::Path<i32>) -> impl Responder {
+pub async fn show(tmpl: web::Data<tera::Tera>, info: web::Path<i32>, messages: IncomingFlashMessages)
+                  -> impl Responder {
   info!("Called show");
   let info = info.into_inner();
   let post = data::get(info);
   let mut context = Context::new();
+  for message in messages.iter() {
+    match message.level() {
+      Level::Success => context.insert("success", &message.content()),
+      Level::Error => context.insert("error", &message.content()),
+      _ => (),
+    }
+  }
   context.insert("post", &post);
   let body_str = tmpl.render("show.html", &context).unwrap();
   HttpResponse::Ok().content_type("text/html; charset=utf-8").body(body_str)


### PR DESCRIPTION
[Webアプリ実装で学ぶ、現場で役立つRust入門](https://atmarkit.itmedia.co.jp/ait/series/36943/)の第5回を実施
- 投稿後および編集後のフラッシュメッセージを表示できるように修正
  （投稿表示用ハンドラの更新漏れ）
  `投稿表示ページのshowハンドラー関数も同様なので、配布サンプルを参照してください。`の見落とし