### PR TITLE
Fix: Android App for Gemini 1.5

### DIFF
--- a/kotlin/Android/MyGeminiApplication/app/src/main/java/com/example/mygeminiapplication/BakingViewModel.kt
+++ b/kotlin/Android/MyGeminiApplication/app/src/main/java/com/example/mygeminiapplication/BakingViewModel.kt
@@ -19,13 +19,10 @@ class BakingViewModel : ViewModel() {
 
     private val generativeModel = GenerativeModel(
         //  gemini 1.0
-    //  modelName = "gemini-pro-vision",
-    //  apiKey = BuildConfig.apiKey
+        //  modelName = "gemini-pro-vision",
         //  gemini 1.5
         modelName = "gemini-1.5-pro-latest",
-        apiKey= buildString {
-            append("AIzaSyCWqiwEQYQCwqZ0fjJRnLW2xQxM8LeLiAg")
-        }
+        apiKey = BuildConfig.apiKey
     )
 
     fun sendPrompt(

--- a/kotlin/Android/MyGeminiApplication/gradle/libs.versions.toml
+++ b/kotlin/Android/MyGeminiApplication/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 agp = "8.5.0-beta01"
 kotlin = "1.9.23"
-coreKtx = "1.12.0"
+coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
-lifecycleRuntimeKtx = "2.7.0"
-lifecycleViewmodelCompose = "2.7.0"
-activityCompose = "1.8.2"
-composeBom = "2024.04.00"
-generativeai = "0.3.0"
+lifecycleRuntimeKtx = "2.8.0"
+lifecycleViewmodelCompose = "2.8.0"
+activityCompose = "1.9.0"
+composeBom = "2024.05.00"
+generativeai = "0.6.0"
 googleAndroidLibrariesMapsplatformSecretsGradlePlugin = "2.0.1"
 
 [libraries]
@@ -25,7 +25,7 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version = "1.6.5" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version = "1.6.7" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 generativeai = { group = "com.google.ai.client.generativeai", name = "generativeai", version.ref = "generativeai" }


### PR DESCRIPTION
Gemini 1.5 を利用するアプリを改修
- API Keyをプロパティに移動し、隠ぺいする
- 依存関係を最新化する