### PR TITLE
Fix: Japanese String from Shift-JIS to UTF-8

### DIFF
--- a/net/C#/LineFonts/LineFonts/Form1.cs
+++ b/net/C#/LineFonts/LineFonts/Form1.cs
@@ -15,10 +15,10 @@ namespace LineFonts
             InitCustomLabelFont();
 
             RegularLabel.Font = new Font(pfc.Families[0], RegularLabel.Font.Size, FontStyle.Regular);
-            RegularLabel.Text = "•W€ƒtƒHƒ“ƒg";
+            RegularLabel.Text = "æ¨™æº–ãƒ•ã‚©ãƒ³ãƒˆ";
 
             BoldLabel.Font = new Font(pfc.Families[1], BoldLabel.Font.Size, FontStyle.Bold);
-            BoldLabel.Text = "‘¾šƒtƒHƒ“ƒg";
+            BoldLabel.Text = "å¤ªå­—ãƒ•ã‚©ãƒ³ãƒˆ";
         }
 
         public void InitCustomLabelFont()

--- a/net/C#/LineFonts/LineFonts9/Form1.cs
+++ b/net/C#/LineFonts/LineFonts9/Form1.cs
@@ -15,10 +15,10 @@ namespace LineFonts
             InitCustomLabelFont();
 
             RegularLabel.Font = new Font(pfc.Families[0], RegularLabel.Font.Size, FontStyle.Regular);
-            RegularLabel.Text = "•W€ƒtƒHƒ“ƒg";
+            RegularLabel.Text = "æ¨™æº–ãƒ•ã‚©ãƒ³ãƒˆ";
 
             BoldLabel.Font = new Font(pfc.Families[1], BoldLabel.Font.Size, FontStyle.Bold);
-            BoldLabel.Text = "‘¾šƒtƒHƒ“ƒg";
+            BoldLabel.Text = "å¤ªå­—ãƒ•ã‚©ãƒ³ãƒˆ";
         }
 
         public void InitCustomLabelFont()


### PR DESCRIPTION
テキストの既定値が Shift-JIS から UTF-8 に変わった模様であるため、従来、Shift-JISで記述していた日本語をUTF-8に変更する
- .NET 8 ターゲットのプロジェクト
- .NET 9 ターゲットのプロジェクト