### PR TITLE
Update: Emulator to Pixel 8

### DIFF
--- a/net/MAUI/MauiApp2/MauiApp2/MauiApp2.csproj.user
+++ b/net/MAUI/MauiApp2/MauiApp2/MauiApp2.csproj.user
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <IsFirstTimeProjectOpen>False</IsFirstTimeProjectOpen>
     <ActiveDebugFramework>net8.0-android</ActiveDebugFramework>
-    <ActiveDebugProfile>Pixel 5 - API 34 (Android 14.0 - API 34)</ActiveDebugProfile>
+    <ActiveDebugProfile>Pixel 8 API 34 (Android 14.0 - API 34)</ActiveDebugProfile>
     <SelectedPlatformGroup>Emulator</SelectedPlatformGroup>
-    <DefaultDevice>pixel_5_-_api_34</DefaultDevice>
+    <DefaultDevice>Pixel_8_API_34</DefaultDevice>
   </PropertyGroup>
   <ItemGroup>
     <None Update="App.xaml">


### PR DESCRIPTION
VS2022 17.10.3 / MAUI 8.0.40(SP5)環境にて
Android Studioで利用したPixel 8 イメージを利用できるようになった