### PR TITLE
Change: Android Emulator to Pixel 5

### DIFF
--- a/net/MAUI/MauiApp2/MauiApp2/MauiApp2.csproj.user
+++ b/net/MAUI/MauiApp2/MauiApp2/MauiApp2.csproj.user
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <IsFirstTimeProjectOpen>False</IsFirstTimeProjectOpen>
     <ActiveDebugFramework>net8.0-android</ActiveDebugFramework>
-    <ActiveDebugProfile>Pixel 8 API 34 (Android 14.0 - API 34)</ActiveDebugProfile>
+    <ActiveDebugProfile>Pixel 5 - API 34 (Android 14.0 - API 34)</ActiveDebugProfile>
     <SelectedPlatformGroup>Emulator</SelectedPlatformGroup>
-    <DefaultDevice>Pixel_8_API_34</DefaultDevice>
+    <DefaultDevice>pixel_5_-_api_34</DefaultDevice>
   </PropertyGroup>
   <ItemGroup>
     <None Update="App.xaml">


### PR DESCRIPTION
Visual Studio 2022 17.11.4 更新に際し、Android Emulator の仮想デバイスを Pixel 5 に変更