### PR TITLE
Update: Upgrade Kotlin version to 2.1.10

### DIFF
--- a/kotlin/spring/BatchBranch/build.gradle.kts
+++ b/kotlin/spring/BatchBranch/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchConcurrent/build.gradle.kts
+++ b/kotlin/spring/BatchConcurrent/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchCsvExport/build.gradle.kts
+++ b/kotlin/spring/BatchCsvExport/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
-	kotlin("plugin.jpa") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
+	kotlin("plugin.jpa") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchCsvImport/build.gradle.kts
+++ b/kotlin/spring/BatchCsvImport/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
-	kotlin("plugin.jpa") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
+	kotlin("plugin.jpa") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchHelloWorldChunk/build.gradle.kts
+++ b/kotlin/spring/BatchHelloWorldChunk/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchHelloWorldTasklet/build.gradle.kts
+++ b/kotlin/spring/BatchHelloWorldTasklet/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchInMemory/build.gradle.kts
+++ b/kotlin/spring/BatchInMemory/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
-	kotlin("plugin.jpa") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
+	kotlin("plugin.jpa") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.0.4-SNAPSHOT"
+version = "0.0.5-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 repositories {

--- a/kotlin/spring/BatchPartitioner/build.gradle.kts
+++ b/kotlin/spring/BatchPartitioner/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchRetryChunk/build.gradle.kts
+++ b/kotlin/spring/BatchRetryChunk/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchRetryTasklet/build.gradle.kts
+++ b/kotlin/spring/BatchRetryTasklet/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {

--- a/kotlin/spring/BatchTestTasklet/build.gradle.kts
+++ b/kotlin/spring/BatchTestTasklet/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
 	id("org.springframework.boot") version "3.4.0"
 	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("jvm") version "2.1.0"
-	kotlin("plugin.spring") version "2.1.0"
+	kotlin("jvm") version "2.1.10"
+	kotlin("plugin.spring") version "2.1.10"
 }
 
 group = "com.example"
-version = "0.1.0-SNAPSHOT"
+version = "0.1.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_22
 
 configurations {
@@ -14,6 +14,8 @@ configurations {
 		extendsFrom(configurations.annotationProcessor.get())
 	}
 }
+
+var mockitoAgent = configurations.create("mockitoAgent")
 
 repositories {
 	mavenCentral()
@@ -32,6 +34,13 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.batch:spring-batch-test")
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+	mockitoAgent("org.mockito:mockito-core") { isTransitive = false }
+}
+
+tasks {
+	test {
+		jvmArgs("-javaagent:${mockitoAgent.asPath}")
+	}
 }
 
 tasks.named("compileKotlin", org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask::class.java) {


### PR DESCRIPTION
Spring Boot Applicationで使用するKotlinを2.1.10に更新する
同時に、テストで使用するmockitoをJDK21以降でAgent起動するための修正を行う