### PR TITLE
Fix: Pull Requests from Dapendabot about Angular / Vue Projects

### DIFF
--- a/js/angular/basic_20190223/app/kanko/kankoClient/package-lock.json
+++ b/js/angular/basic_20190223/app/kanko/kankoClient/package-lock.json
@@ -8221,9 +8221,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {

--- a/js/angular/vs-angular/package-lock.json
+++ b/js/angular/vs-angular/package-lock.json
@@ -1,30 +1,30 @@
 {
   "name": "vs-angular",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vs-angular",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@angular/animations": "^16.2.12",
         "@angular/common": "^16.2.12",
         "@angular/compiler": "~16.2.12",
         "@angular/core": "^16.2.12",
-        "@angular/forms": "^16.0.0",
-        "@angular/platform-browser": "^16.0.0",
+        "@angular/forms": "^16.2.12",
+        "@angular/platform-browser": "^16.2.12",
         "@angular/platform-browser-dynamic": "^16.2.12",
-        "@angular/router": "^16.0.0",
+        "@angular/router": "^16.2.12",
         "rxjs": "~7.4.0",
         "tslib": "^1.9.0",
         "zone.js": "~0.13.0"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.0.0",
-        "@angular/cli": "^16.0.0",
-        "@angular/compiler-cli": "^16.0.0",
-        "@angular/language-service": "~16.0.0",
+        "@angular-devkit/build-angular": "^16.2.10",
+        "@angular/cli": "^16.2.10",
+        "@angular/compiler-cli": "^16.2.12",
+        "@angular/language-service": "~16.0.6",
         "@types/jasmine": "~4.3.0",
         "@types/jasminewd2": "~2.0.10",
         "@types/node": "~18.11.10",
@@ -6951,9 +6951,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
follow-redirects 1.15.6使用に関するdapendabotからの PRを確認し、最新化する
- 最新ソースでは、1.15.9を使用しているため、問題なし