### PR TITLE
Update: Visual Studio 2022 17.14 Preview 2.0 (#1976)

### DIFF
--- a/net/MAUI/MauiApp10/MauiApp10/MauiApp10.csproj.user
+++ b/net/MAUI/MauiApp10/MauiApp10/MauiApp10.csproj.user
@@ -2,7 +2,7 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <IsFirstTimeProjectOpen>False</IsFirstTimeProjectOpen>
-    <ActiveDebugFramework>net10.0-android35.0</ActiveDebugFramework>
+    <ActiveDebugFramework>net10.0-android</ActiveDebugFramework>
     <ActiveDebugProfile>Pixel 9 API 35 (Android 15.0 - API 35)</ActiveDebugProfile>
     <SelectedPlatformGroup>Emulator</SelectedPlatformGroup>
     <DefaultDevice>Pixel_9_API_35</DefaultDevice>


### PR DESCRIPTION
Visual Studio 2022 17.14 Preview 2.0 にて、各Frameworkの表記が変更になった模様
- net10.0-android35.0 -> net10.0-android